### PR TITLE
docs: replace 'dependabot' with 'renovate' in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ copier template for Python-based libraries / packages
 - opinionated
 - use namespace packages to avoid naming collisions
 - use pdm, pyenv & tox for all our development needs
-- use dependabot, pdm, pre-commit & release-please for all our packaging needs
+- use pdm, pre-commit, release-please & renovate for all our packaging needs
 
 __namespaces__
 


### PR DESCRIPTION
We already made the switch but README.md wasn't updated accordingly.