### PR TITLE
feat: switch back to dependabot (with custom config)

### DIFF
--- a/template/.github/dependabot.yaml
+++ b/template/.github/dependabot.yaml
@@ -1,0 +1,27 @@
+---
+# enable dependabot's scanning but do not allow creation of pull requests
+# (please use 'scripts/update_dependencies' to update the dependencies)
+#
+# - dependabot does not understand PEP-621 repositories (pyproject.toml)
+# - dependabot expects the filename to end in '<...>requirements.txt' and
+#   ignores requirements-dev.txt ('dev-requirements.txt' would work but
+#   that's kinda stupid since the requirements files are no longer grouped
+#   by name -> we should optimize for humans instead of computers)
+# - renovate supports PEP-621 but it gets confused since we provide
+#   requirements.txt which makes it ignore pyproject.toml and pdm.lock
+#
+# --> provide our own mechanism to update requirements*.txt AND pdm.lock
+
+version: 2
+
+updates:
+  - package-ecosystem: pip
+    directory: "/"
+    schedule:
+      interval: daily
+      time: "13:00"
+    groups:
+      python-packages:
+        patterns:
+          - "*"
+    open-pull-requests-limit: 0

--- a/template/renovate.json
+++ b/template/renovate.json
@@ -1,6 +1,0 @@
-{
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:recommended"
-  ]
-}

--- a/template/scripts/run_tests.jinja
+++ b/template/scripts/run_tests.jinja
@@ -7,15 +7,15 @@ set -e
 set -u
 
 # code quality
-pdm run flake8 {{package_namespace}}/ examples/ tests/
+pdm run flake8 {{ package_namespace }}/ examples/ tests/
 
 # code style
 # (pylint is configured to accept "less than perfect")
-pdm run pylint {{package_namespace}}/ examples/ tests/
+pdm run pylint {{ package_namespace }}/ examples/ tests/
 {% if is_typed %}
 
 # validate type hints (package)
-pdm run mypy -p {{package_namespace}}.{{package_name}}
+pdm run mypy -p {{ package_namespace }}.{{ package_name }}
 
 # validate type hints (extra files)
 # (we need to be careful since there might be no files)

--- a/template/scripts/update_dependencies.jinja
+++ b/template/scripts/update_dependencies.jinja
@@ -1,0 +1,44 @@
+#!/bin/bash
+#
+# update Python dependencies using PDM
+# (requires `gh auth login`)
+#
+
+set -e
+set -u
+
+branch_name="fb-update-dependencies_`date +'%s'`"
+
+git stash save
+current_branch=`git branch --show-current`
+git checkout {{ default_branch }}
+git pull
+git checkout -b $branch_name
+pdm update --update-all
+git add --update
+git commit -m "chore: update dependencies (pdm update --update-all)"
+git push --set-upstream origin $branch_name
+git checkout $current_branch
+
+# restore original state
+git checkout $current_branch
+if git stash show ; then
+    git stash pop
+fi
+
+# if present: use GitHub CLI tools to create a pull request
+if command -v gh >/dev/null ; then
+    # I'm sorry but this is the best I could come up with to test if there
+    # is a label "dependencies".
+    #  - 'gh label list' limits its output to 30 tags
+    #  - '--search' will find close matches (e.g. typos) and is not reliable
+    #  - --jq='.[] | select(.name=="...")' does not indicate if there was no
+    #    result ('...|jq -e' would, but that would require jq to be installed)
+    if ! gh label list --search="dep" --json='name' --jq='.[]["name"]'|grep -q "^dependencies$" ; then
+        gh label create dependencies --color="#0366d6" --description="update dependency files (pdm.lock & requirements*.txt)"
+    fi
+    gh pr create --assignee="@me" --base={{ default_branch }} --head=$branch_name --fill --label="dependencies"
+else
+    echo "GitHub CLI tools not found. Unable to create a pull request."
+    echo "-> https://github.com/cli/cli"
+fi

--- a/template/tox.ini.jinja
+++ b/template/tox.ini.jinja
@@ -81,7 +81,7 @@ deps =
 # generate a coverage report but do not mesurements and do not fail
 # (we will combine all measurements into a single report later on)
 commands =
-    pytest --cov --cov-append --cov-report= --cov-fail-under=0 tests {posargs}
+    pytest --cov={{ package_namespace }}.{{ package_name }} --cov-append --cov-report= --cov-fail-under=0 {posargs: tests/}
 
 [testenv:coverage_clean]
 deps = coverage
@@ -93,5 +93,5 @@ commands =
 deps = coverage
 skip_install = true
 commands =
-    coverage report
+    coverage report --show-missing
     coverage html


### PR DESCRIPTION
enable dependabot's scanning but do not allow creation of pull requests
(please use 'scripts/update_dependencies' to update the dependencies)
 
- dependabot does not understand PEP-621 repositories (pyproject.toml)
- dependabot expects the filename to end in '<...>requirements.txt' and
  ignores requirements-dev.txt ('dev-requirements.txt' would work but
  that's kinda stupid since the requirements files are no longer grouped
  by name -> we should optimize for humans instead of computers)
- renovate supports PEP-621 but it gets confused since we provide
  requirements.txt which makes it ignore pyproject.toml and pdm.lock

--> provide our own mechanism to update requirements*.txt AND pdm.lock